### PR TITLE
updated base iam policy due to permission errors while deploying 9cscan

### DIFF
--- a/bootstrap/iam/9cscan-policy.json
+++ b/bootstrap/iam/9cscan-policy.json
@@ -30,7 +30,10 @@
         "states:StartExecution",
         "states:CreateStateMachine",
         "cloudformation:*",
-        "lambda:CreateEventSourceMapping"
+        "lambda:CreateEventSourceMapping",
+        "lambda:InvokeFunction",
+        "lambda:UpdateFunctionCode",
+        "lambda:UpdateFunctionConfiguration"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
There was permission errors while deploying 9cscan cloud backend for testing.

Need to add these lines below:
```
"lambda:InvokeFunction",
"lambda:UpdateFunctionCode",
"lambda:UpdateFunctionConfiguration"
```